### PR TITLE
Change the way single errors are treated

### DIFF
--- a/multierror.go
+++ b/multierror.go
@@ -13,7 +13,7 @@ type Error struct {
 func (e *Error) Error() string {
 	buf := bytes.NewBuffer(nil)
 
-	fmt.Fprintf(buf, "%d error(s) occurred:", len(e.errs))
+	fmt.Fprintf(buf, "%d errors occurred:", len(e.errs))
 	for _, err := range e.errs {
 		fmt.Fprintf(buf, "\n%v", err)
 	}
@@ -22,7 +22,15 @@ func (e *Error) Error() string {
 
 // Append creates a new mutlierror.Error structure or appends the arguments to an existing multierror
 // err can be nil, or can be a non-multierror error.
+//
+// If err is nil and errs has only one element, that element is returned.
+// I.e. a singleton error is never treated and (thus rendered) as a multierror.
+// This also also effectively allows users to just pipe through the error value of a function call,
+// without having to first check whether the error is non-nil.
 func Append(err error, errs ...error) error {
+	if err == nil && len(errs) == 1 {
+		return errs[0]
+	}
 	if err == nil {
 		return &Error{errs}
 	}

--- a/multierror_test.go
+++ b/multierror_test.go
@@ -13,13 +13,12 @@ func TestAppend(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got, want := err.Error(), `1 error(s) occurred:
-an error`; got != want {
+	if got, want := err.Error(), `an error`; got != want {
 		t.Errorf("got: %q, want: %q", got, want)
 	}
 
 	err = Append(err, errors.Errorf("another error"))
-	if got, want := err.Error(), `2 error(s) occurred:
+	if got, want := err.Error(), `2 errors occurred:
 an error
 another error`; got != want {
 		t.Errorf("got: %q, want: %q", got, want)
@@ -31,10 +30,17 @@ another error`; got != want {
 		t.Fatal(err)
 	}
 
-	if got, want := err.Error(), `2 error(s) occurred:
+	if got, want := err.Error(), `2 errors occurred:
 old error
 new error`; got != want {
 		t.Errorf("got: %q, want: %q", got, want)
 	}
+}
 
+func TestAppendNil(t *testing.T) {
+	var err error
+	err = Append(err, nil)
+	if err != nil {
+		t.Errorf("should be nil")
+	}
 }


### PR DESCRIPTION
There is a potential pitfall when using this library:

```
var errors error
...
errors = multierror.Append(errors, doSomething())
...
return errors
```

Users might expect that if `doSomething` returns nil, then this
function will also return nil, and it thus might be the cause of subtle
bugs.

This commit changes the behaviour of Append slightly:

There will be never an instance of multierror that has exactly one
error. Or in other words: there will never be a multi-error that is
single and not multi.

Which kinda makes sense if you think about it. Having a message like:

```
there are 1 error(s):
something wrong
```

Is mostly just noise.

Implementation-wise it's straight forward.