### PR TITLE
Remove spurious nils in multierror

### DIFF
--- a/multierror.go
+++ b/multierror.go
@@ -31,6 +31,9 @@ func Append(err error, errs ...error) error {
 	if err == nil && len(errs) == 1 {
 		return errs[0]
 	}
+	if len(errs) == 1 && errs[0] == nil {
+		return err
+	}
 	if err == nil {
 		return &Error{errs}
 	}

--- a/multierror_test.go
+++ b/multierror_test.go
@@ -44,3 +44,24 @@ func TestAppendNil(t *testing.T) {
 		t.Errorf("should be nil")
 	}
 }
+
+func TestAppendNilOnSomething(t *testing.T) {
+	err1 := errors.Errorf("test")
+	errs := err1
+	errs = Append(errs, nil)
+
+	if got, want := errs, err1; got != want {
+		t.Errorf("got: %v, want: %v", got, want)
+	}
+}
+
+func TestAppendMultiple(t *testing.T) {
+	err1 := errors.Errorf("test")
+	var errs error
+	errs = Append(nil, err1)
+	errs = Append(errs, nil)
+
+	if got, want := errs, err1; got != want {
+		t.Errorf("got: %v, want: %v", got, want)
+	}
+}


### PR DESCRIPTION
The intention of #1 was to allow the simple pattern:

```
for ... {
  errs = multierror.Append(errs, foo())
}
```

However, albeit correct in terms of err != nil,
the resulting multierror was ugly because it contained a lot of `nil` since
it would have appended those nils once the multierror has been created
for the first not-nil error.